### PR TITLE
Skip shell substitution

### DIFF
--- a/makefiles/0-directories.mk
+++ b/makefiles/0-directories.mk
@@ -26,8 +26,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
 # POSSIBILITY OF SUCH DAMAGE.
 
-UNISTC_ROOT_DIR := $(shell dirname "$(dir $(abspath $(lastword $(MAKEFILE_LIST))))")
-UNISTC_DIR := $(UNISTC_ROOT_DIR)/include
-HAL_DIR := $(UNISTC_ROOT_DIR)/hal
-DRIVER_DIR := $(UNISTC_ROOT_DIR)/drivers
-MAKE_DIR := $(UNISTC_ROOT_DIR)/makefiles
+UNISTC_ROOT_DIR := $(dir $(abspath $(dir $(lastword $(MAKEFILE_LIST)))))
+UNISTC_DIR := $(UNISTC_ROOT_DIR)include
+HAL_DIR := $(UNISTC_ROOT_DIR)hal
+DRIVER_DIR := $(UNISTC_ROOT_DIR)drivers
+MAKE_DIR := $(UNISTC_ROOT_DIR)makefiles

--- a/makefiles/1-mcu-settings.mk
+++ b/makefiles/1-mcu-settings.mk
@@ -115,6 +115,8 @@ DRIVER_OBJS := $(subst $(DRIVER_DIR),$(OBJDIR),$(subst .c,.rel,$(DRIVER_SRCS)))
 HAL_OBJS := $(subst $(HAL_DIR),$(OBJDIR),$(subst .c,.rel,$(HAL_SRCS)))
 LOCAL_OBJS := $(addprefix $(OBJDIR)/,$(subst .c,.rel,$(LOCAL_SRCS)))
 
+OBJDIR_TREE := $(sort $(dir $(DRIVER_OBJS) $(HAL_OBJS) $(LOCAL_OBJS)))
+
 ifeq ($(HAS_DUAL_DPTR),y)
 	DUAL_DPTR_SUPPORT := $(OBJDIR)/crtxinit.rel
 else

--- a/makefiles/1-mcu-settings.mk
+++ b/makefiles/1-mcu-settings.mk
@@ -107,13 +107,13 @@ OBJDIR := $(BUILD_ROOT)
 FW_FILE := $(OBJDIR)/$(PROJECT_NAME).ihx
 DEP_FILE := $(OBJDIR)/dependencies.mk
 
-DRIVER_SRCS := $(filter $(DRIVER_DIR)/%, $(SRCS))
-HAL_SRCS := $(filter $(HAL_DIR)/%, $(SRCS))
-LOCAL_SRCS := $(filter-out $(DRIVER_DIR)/%, $(filter-out $(HAL_DIR)/%, $(SRCS)))
+DRIVER_SRCS := $(filter $(DRIVER_DIR)%, $(SRCS))
+HAL_SRCS := $(filter $(HAL_DIR)%, $(SRCS))
+LOCAL_SRCS := $(filter-out $(DRIVER_DIR)%, $(filter-out $(HAL_DIR)%, $(SRCS)))
 
-DRIVER_OBJS := $(patsubst %.c, $(OBJDIR)/%.rel, $(shell srcDir="$(DRIVER_DIR)";for srcFile in $(DRIVER_SRCS); do echo "$${srcFile#$$srcDir/}"; done))
-HAL_OBJS := $(patsubst %.c, $(OBJDIR)/%.rel, $(shell srcDir="$(HAL_DIR)";for srcFile in $(HAL_SRCS); do echo "$${srcFile#$$srcDir/}"; done))
-LOCAL_OBJS := $(patsubst %.c, $(OBJDIR)/%.rel, $(LOCAL_SRCS))
+DRIVER_OBJS := $(subst $(DRIVER_DIR),$(OBJDIR),$(subst .c,.rel,$(DRIVER_SRCS)))
+HAL_OBJS := $(subst $(HAL_DIR),$(OBJDIR),$(subst .c,.rel,$(HAL_SRCS)))
+LOCAL_OBJS := $(addprefix $(OBJDIR)/,$(subst .c,.rel,$(LOCAL_SRCS)))
 
 ifeq ($(HAS_DUAL_DPTR),y)
 	DUAL_DPTR_SUPPORT := $(OBJDIR)/crtxinit.rel

--- a/makefiles/1-pc-settings.mk
+++ b/makefiles/1-pc-settings.mk
@@ -73,6 +73,8 @@ DRIVER_OBJS := $(subst $(DRIVER_DIR),$(OBJDIR),$(subst .c,.o,$(DRIVER_SRCS)))
 HAL_OBJS := $(subst $(HAL_DIR),$(OBJDIR),$(subst .c,.o,$(HAL_SRCS)))
 LOCAL_OBJS := $(addprefix $(OBJDIR)/,$(subst .c,.o,$(LOCAL_SRCS)))
 
+OBJDIR_TREE := $(sort $(dir $(DRIVER_OBJS) $(HAL_OBJS) $(LOCAL_OBJS)))
+
 # Rules ----------------------------------------------------------------
 
 .PHONY: all clean

--- a/makefiles/1-pc-settings.mk
+++ b/makefiles/1-pc-settings.mk
@@ -65,13 +65,13 @@ OBJDIR := $(BUILD_ROOT)/$(BUILD_DIR)
 FW_FILE := $(OBJDIR)/$(PROJECT_NAME)
 DEP_FILE := $(OBJDIR)/dependencies.mk
 
-DRIVER_SRCS := $(filter $(DRIVER_DIR)/%, $(SRCS))
-HAL_SRCS := $(filter $(HAL_DIR)/%, $(SRCS))
-LOCAL_SRCS := $(filter-out $(DRIVER_DIR)/%, $(filter-out $(HAL_DIR)/%, $(SRCS)))
+DRIVER_SRCS := $(filter $(DRIVER_DIR)%, $(SRCS))
+HAL_SRCS := $(filter $(HAL_DIR)%, $(SRCS))
+LOCAL_SRCS := $(filter-out $(DRIVER_DIR)%, $(filter-out $(HAL_DIR)%, $(SRCS)))
 
-DRIVER_OBJS := $(patsubst %.c, $(OBJDIR)/%.o, $(shell srcDir="$(DRIVER_DIR)";for srcFile in $(DRIVER_SRCS); do echo "$${srcFile#$$srcDir/}"; done))
-HAL_OBJS := $(patsubst %.c, $(OBJDIR)/%.o, $(shell srcDir="$(HAL_DIR)";for srcFile in $(HAL_SRCS); do echo "$${srcFile#$$srcDir/}"; done))
-LOCAL_OBJS := $(patsubst %.c, $(OBJDIR)/%.o, $(LOCAL_SRCS))
+DRIVER_OBJS := $(subst $(DRIVER_DIR),$(OBJDIR),$(subst .c,.o,$(DRIVER_SRCS)))
+HAL_OBJS := $(subst $(HAL_DIR),$(OBJDIR),$(subst .c,.o,$(HAL_SRCS)))
+LOCAL_OBJS := $(addprefix $(OBJDIR)/,$(subst .c,.o,$(LOCAL_SRCS)))
 
 # Rules ----------------------------------------------------------------
 

--- a/makefiles/2-mcu-rules.mk
+++ b/makefiles/2-mcu-rules.mk
@@ -30,13 +30,13 @@
 # documentation (which the SDCC manual says should apply), so we 
 # need to compensate for this. We also need to create subdirectories
 # under $(OBJDIR) as needed because SDCC can't do it.
-$(DEP_FILE):
-	@mkdir -p $(OBJDIR)
+
+$(OBJDIR) $(OBJDIR_TREE):
+	@mkdir -p $@
+
+$(DEP_FILE): $(OBJDIR)
 	@for srcFile in $(LOCAL_SRCS); do $(CC) $(CPPFLAGS) -MM $${srcFile} >> $(DEP_FILE); done
 	@sed -i "s/^\(.*\.rel:.*\)/$(BUILD_ROOT)\/\1/g" $(DEP_FILE)
-	@for objFile in $(DRIVER_OBJS); do objPath="$${objFile%/*}"; if [ ! -d "$${objPath}" ]; then mkdir -p "$${objPath}"; fi; done
-	@for objFile in $(HAL_OBJS); do objPath="$${objFile%/*}"; if [ ! -d "$${objPath}" ]; then mkdir -p "$${objPath}"; fi; done
-	@for objFile in $(LOCAL_OBJS); do objPath="$${objFile%/*}"; if [ ! -d "$${objPath}" ]; then mkdir -p "$${objPath}"; fi; done
 
 $(FW_FILE): $(DRIVER_OBJS) $(HAL_OBJS) $(LOCAL_OBJS) $(DUAL_DPTR_SUPPORT)
 	$(CC) $(LDFLAGS) -o $@ $^
@@ -44,11 +44,11 @@ $(FW_FILE): $(DRIVER_OBJS) $(HAL_OBJS) $(LOCAL_OBJS) $(DUAL_DPTR_SUPPORT)
 $(OBJDIR)/crtxinit.rel: $(HAL_DIR)/crtxinit.asm
 	$(AS) $(ASFLAGS) $@ $<
 
-$(DRIVER_OBJS):
+$(DRIVER_OBJS): $(OBJDIR_TREE)
 	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR),$(DRIVER_DIR),$(subst .rel,.c,$@))
 
-$(HAL_OBJS):
+$(HAL_OBJS): $(OBJDIR_TREE)
 	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR),$(HAL_DIR),$(subst .rel,.c,$@))
 
-$(LOCAL_OBJS):
+$(LOCAL_OBJS): $(OBJDIR_TREE)
 	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR)/,,$(subst .rel,.c,$@))

--- a/makefiles/2-mcu-rules.mk
+++ b/makefiles/2-mcu-rules.mk
@@ -45,10 +45,10 @@ $(OBJDIR)/crtxinit.rel: $(HAL_DIR)/crtxinit.asm
 	$(AS) $(ASFLAGS) $@ $<
 
 $(DRIVER_OBJS):
-	$(CC) $(CFLAGS) -o $@ -c $(patsubst %.rel, $(DRIVER_DIR)/%.c, $(shell srcDir="$(OBJDIR)";srcFile="$@";echo "$${srcFile#$$srcDir/}"))
+	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR),$(DRIVER_DIR),$(subst .rel,.c,$@))
 
 $(HAL_OBJS):
-	$(CC) $(CFLAGS) -o $@ -c $(patsubst %.rel, $(HAL_DIR)/%.c, $(shell srcDir="$(OBJDIR)";srcFile="$@";echo "$${srcFile#$$srcDir/}"))
+	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR),$(HAL_DIR),$(subst .rel,.c,$@))
 
 $(LOCAL_OBJS):
-	$(CC) $(CFLAGS) -o $@ -c $(patsubst %.rel, %.c, $(shell srcDir="$(OBJDIR)";srcFile="$@";echo "$${srcFile#$$srcDir/}"))
+	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR)/,,$(subst .rel,.c,$@))

--- a/makefiles/2-pc-rules.mk
+++ b/makefiles/2-pc-rules.mk
@@ -26,24 +26,21 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
 # POSSIBILITY OF SUCH DAMAGE.
 
-$(OBJDIR):
-	@mkdir -p $(OBJDIR)
+$(OBJDIR) $(OBJDIR_TREE):
+	@mkdir -p $@
 
 $(DEP_FILE): $(OBJDIR)
 	$(CC) $(CFLAGS) -MM -MF - $(SRCS) > $(DEP_FILE)
-	sed -i "s/^\(.*\.o:.*\)/$(BUILD_ROOT)\/$(BUILD_DIR)\/\1/g" $(DEP_FILE)
-	@for objFile in $(DRIVER_OBJS); do objPath="$${objFile%/*}"; if [ ! -d "$${objPath}" ]; then mkdir -p "$${objPath}"; fi; done
-	@for objFile in $(HAL_OBJS); do objPath="$${objFile%/*}"; if [ ! -d "$${objPath}" ]; then mkdir -p "$${objPath}"; fi; done
-	@for objFile in $(LOCAL_OBJS); do objPath="$${objFile%/*}"; if [ ! -d "$${objPath}" ]; then mkdir -p "$${objPath}"; fi; done
+	@sed -i "s/^\(.*\.o:.*\)/$(BUILD_ROOT)\/$(BUILD_DIR)\/\1/g" $(DEP_FILE)
 
 $(FW_FILE): $(DRIVER_OBJS) $(HAL_OBJS) $(LOCAL_OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^
 
-$(DRIVER_OBJS):
+$(DRIVER_OBJS): $(OBJDIR_TREE)
 	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR),$(DRIVER_DIR),$(subst .o,.c,$@))
 
-$(HAL_OBJS):
+$(HAL_OBJS): $(OBJDIR_TREE)
 	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR),$(HAL_DIR),$(subst .o,.c,$@))
 
-$(LOCAL_OBJS):
+$(LOCAL_OBJS): $(OBJDIR_TREE)
 	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR)/,,$(subst .o,.c,$@))

--- a/makefiles/2-pc-rules.mk
+++ b/makefiles/2-pc-rules.mk
@@ -40,10 +40,10 @@ $(FW_FILE): $(DRIVER_OBJS) $(HAL_OBJS) $(LOCAL_OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^
 
 $(DRIVER_OBJS):
-	$(CC) $(CFLAGS) -o $@ -c $(patsubst %.o, $(DRIVER_DIR)/%.c, $(shell srcDir="$(OBJDIR)";srcFile="$@";echo "$${srcFile#$$srcDir/}"))
+	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR),$(DRIVER_DIR),$(subst .o,.c,$@))
 
 $(HAL_OBJS):
-	$(CC) $(CFLAGS) -o $@ -c $(patsubst %.o, $(HAL_DIR)/%.c, $(shell srcDir="$(OBJDIR)";srcFile="$@";echo "$${srcFile#$$srcDir/}"))
+	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR),$(HAL_DIR),$(subst .o,.c,$@))
 
 $(LOCAL_OBJS):
-	$(CC) $(CFLAGS) -o $@ -c $(patsubst %.o, %.c, $(shell srcDir="$(OBJDIR)";srcFile="$@";echo "$${srcFile#$$srcDir/}"))
+	$(CC) $(CFLAGS) -o $@ -c $(subst $(OBJDIR)/,,$(subst .o,.c,$@))


### PR DESCRIPTION
I came here from [ReedTripRadio](https://github.com/mightymos/ReedTripRadio).  I ran into some errors while trying to compile on both MacOS and Raspbian, and it looks like [other](https://github.com/mightymos/ReedTripRadio/issues/5#issue-1534013081) [users](https://github.com/mightymos/ReedTripRadio/issues/4#issuecomment-1382693791) have as well.  It looks like make was getting confused with string and shell substitution.

This PR simplifies things by using make's internal string functions where possible.  This works around the above compile errors and is more readable(IMHO).